### PR TITLE
Correct the dataset's match IDs and train/val/test split

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The toolkit produces per-match ground truth from raw BePro panoramic recordings.
 
 ```bash
 ./scripts/create_ground_truth.sh 117093          # single match
-./scripts/create_ground_truth.sh 117093 117094   # multiple matches
+./scripts/create_ground_truth.sh 117093 118575   # multiple matches
 ```
 
 Stage-by-stage scripts live under `scripts/` (`trim_video_into_halves.sh`, `convert_raw_to_pitch_plane.sh`, `calibrate_camera.sh`, `convert_pitch_plane_to_image_plane.sh`, `generate_detections.sh`, `convert_coordinates_to_bboxes.sh`, `plot_coordinates_on_video.sh`).

--- a/baselines/bas/config.yaml
+++ b/baselines/bas/config.yaml
@@ -1,8 +1,8 @@
 data:
   root: ./data
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
-  val_matches:   [117098]
-  test_matches:  [117099, 117100]
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]
+  val_matches:   [118578]
+  test_matches:  [128057, 132831]
 
 features:
   name: mvit_b_16x4

--- a/baselines/gsr/config.yaml
+++ b/baselines/gsr/config.yaml
@@ -1,9 +1,9 @@
 # GSR baseline config — edit paths, leave structure.
 data:
   root: ./data                         # SoccerTrack v2 snapshot root
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
-  val_matches:   [117098]
-  test_matches:  [117099, 117100]      # held out for the paper
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]
+  val_matches:   [118578]
+  test_matches:  [128057, 132831]      # held out; matches the SoccerTrack Challenge 2025 test split
 
 detector:
   name: yolov8s

--- a/baselines/mot/config.yaml
+++ b/baselines/mot/config.yaml
@@ -1,8 +1,8 @@
 data:
   root: ./data
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
-  val_matches:   [117098]
-  test_matches:  [117099, 117100]
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]
+  val_matches:   [118578]
+  test_matches:  [128057, 132831]
 
 detector:
   name: yolov8s

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ The project includes shell scripts for common operations:
 
 2. **Download the dataset from Hugging Face**
    ```bash
-   ./scripts/download.sh --dest ./data --match 117099 --match 117100
+   ./scripts/download.sh --dest ./data --match 117092 --match 117093
    ```
    Thin wrapper around `huggingface-cli` / `hf` with per-match filtering and revision pinning.
 

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -47,7 +47,7 @@ Example:
 
 Process multiple matches:
 ```bash
-./scripts/create_ground_truth.sh 117093 117094 117095
+./scripts/create_ground_truth.sh 117093 118575 118576
 ```
 
 ### Individual Steps

--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -523,7 +523,7 @@
 ./scripts/download.sh --dest ./data
 
 # 評価用試合のみ
-./scripts/download.sh --dest ./data --match 117099 --match 117100</code></pre>
+./scripts/download.sh --dest ./data --match 117092 --match 117093</code></pre>
                 </div>
             </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,7 +545,7 @@
 ./scripts/download.sh --dest ./data
 
 # held-out test matches only
-./scripts/download.sh --dest ./data --match 117099 --match 117100</code></pre>
+./scripts/download.sh --dest ./data --match 117092 --match 117093</code></pre>
                 </div>
             </section>
 
@@ -617,9 +617,9 @@ for p in match.gsr_frames(half=1)[0].entities:
                 </p>
 
                 <h3 style="color: #10b981; margin-top: 1.5rem; margin-bottom: 0.5rem;">4. Evaluate</h3>
-                <pre><code>python -m src.evaluation.gs_hota  --pred preds/gsr --gt data/gsr --matches 117099 117100
-python -m src.evaluation.bas_map  --pred preds/bas --gt data/bas --matches 117099 117100
-python -m src.evaluation.mot_hota --pred preds/mot --gt data/mot --matches 117099 117100</code></pre>
+                <pre><code>python -m src.evaluation.gs_hota  --pred preds/gsr --gt data/gsr --matches 128057 132831
+python -m src.evaluation.bas_map  --pred preds/bas --gt data/bas --matches 128057 132831
+python -m src.evaluation.mot_hota --pred preds/mot --gt data/mot --matches 128057 132831</code></pre>
                 <p style="margin-top: 0.75rem;">
                     Starter kits:
                     <a href="https://github.com/AtomScott/SoccerTrack-v2/tree/main/baselines"

--- a/docs/matches.json
+++ b/docs/matches.json
@@ -3,15 +3,15 @@
   "schema_version": 1,
   "updated": "2026-04-22",
   "matches": [
-    { "match_id": "117091", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "A1", "team_right": "A2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117092", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "B1", "team_right": "B2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117093", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "C1", "team_right": "C2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117094", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "D1", "team_right": "D2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117095", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "E1", "team_right": "E2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117096", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "F1", "team_right": "F2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117097", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "G1", "team_right": "G2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117098", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "H1", "team_right": "H2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117099", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "I1", "team_right": "I2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117100", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "J1", "team_right": "J2", "gsr_frames": null, "bas_events": null }
+    { "match_id": "117092", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "A1", "team_right": "A2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "117093", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "B1", "team_right": "B2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118575", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "C1", "team_right": "C2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118576", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "D1", "team_right": "D2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118577", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "E1", "team_right": "E2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118578", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "F1", "team_right": "F2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "128057", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "G1", "team_right": "G2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "128058", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "H1", "team_right": "H2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "132831", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "I1", "team_right": "I2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "132877", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "J1", "team_right": "J2", "gsr_frames": null, "bas_events": null }
   ]
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,7 +37,7 @@ Use the helper script to fetch from Hugging Face (`atomscott/soccertrack-v2`):
 
 ```bash
 ./scripts/download.sh --dest ./data                                    # full dataset
-./scripts/download.sh --dest ./data --match 117099 --match 117100      # subset
+./scripts/download.sh --dest ./data --match 117092 --match 117093      # subset
 ```
 
 `--revision` pins a dataset tag / commit; see `scripts/download.sh --help` for
@@ -50,7 +50,7 @@ Run a quick load against the freshly downloaded data:
 
 ```python
 from src.data_utils.soccertrack_v2 import load_match
-m = load_match("./data", match_id="117099")
+m = load_match("./data", match_id="117093")
 frames = m.gsr_frames(half=1)
 print(len(frames), "GSR frames in 1st half")
 print(len(m.bas_events()), "BAS events")
@@ -89,7 +89,7 @@ running `download.sh` first:
 
 ```python
 from src.data_utils.load_from_hf import load_match_from_hf
-m = load_match_from_hf("117099")
+m = load_match_from_hf("117093")
 ```
 
 `snapshot_download` caches under `HF_HOME` so repeat calls are free.

--- a/docs/task-bas.html
+++ b/docs/task-bas.html
@@ -387,7 +387,7 @@
                 </ul>
                 <p>Reference CLI:</p>
                 <pre><code>python -m src.evaluation.bas_map \
-    --pred preds/bas --gt data/bas --matches 117099 117100 \
+    --pred preds/bas --gt data/bas --matches 128057 132831 \
     --tolerances 1 5</code></pre>
             </section>
 

--- a/docs/task-gsr.html
+++ b/docs/task-gsr.html
@@ -379,7 +379,7 @@
                     Reference CLI:
                 </p>
                 <pre><code>python -m src.evaluation.gs_hota \
-    --pred preds/gsr --gt data/gsr --matches 117099 117100</code></pre>
+    --pred preds/gsr --gt data/gsr --matches 128057 132831</code></pre>
                 <p>
                     The module is a thin wrapper over the upstream
                     <a href="https://github.com/SoccerNet/sn-gamestate">sn-gamestate</a> scorer.

--- a/docs/task-mot.html
+++ b/docs/task-mot.html
@@ -296,7 +296,7 @@
 │   │   ├── gt/
 │   │   │   └── gt.txt
 │   │   └── seqinfo.ini
-│   ├── 117094/
+│   ├── 118575/
 │   │   └── ...
 │   └── ...
 └── raw/
@@ -386,7 +386,7 @@ imExt=.mp4</code></pre>
                 </p>
                 <p>Reference CLI:</p>
                 <pre><code>python -m src.evaluation.mot_hota \
-    --pred preds/mot --gt data/mot --matches 117099 117100</code></pre>
+    --pred preds/mot --gt data/mot --matches 128057 132831</code></pre>
                 <p>
                     Challenge leaderboard: see <a href="https://sites.google.com/g.sp.m.is.nagoya-u.ac.jp/stc2025" style="color: #ff6b35;">SoccerTrack Challenge 2025</a>.
                 </p>

--- a/scripts/create_ground_truth.sh
+++ b/scripts/create_ground_truth.sh
@@ -4,7 +4,7 @@
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <match_id1> [match_id2 ...]"
     echo "Example: $0 117093"
-    echo "Example with multiple matches: $0 117093 117094 117095"
+    echo "Example with multiple matches: $0 117093 118575 118576"
     exit 1
 fi
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -7,7 +7,7 @@
 #   --dest DIR       Target directory (default: ./data)
 #   --revision REV   Pin to a specific dataset revision / tag / commit (default: main)
 #   --match ID       Repeatable. Restrict download to one or more match IDs
-#                    (e.g. --match 117099 --match 117100). Selects gsr/<id>, bas/<id>,
+#                    (e.g. --match 117092 --match 117093). Selects gsr/<id>, bas/<id>,
 #                    mot/<id>, raw/<id>, videos/<id>*. Mutually exclusive with --include.
 #   --include PAT    Repeatable raw include pattern forwarded to huggingface-cli.
 #

--- a/src/evaluation/bas_map.py
+++ b/src/evaluation/bas_map.py
@@ -4,7 +4,7 @@ Computes per-class temporal mean Average Precision at user-supplied tolerance
 windows (1 s and 5 s by default), matching the SoccerNet BAS protocol. Predictions
 must use the same JSON schema as ground truth (see docs/format-bas.md).
 
-    python -m src.evaluation.bas_map --pred PRED_ROOT --gt GT_ROOT --matches 117099 117100 \\
+    python -m src.evaluation.bas_map --pred PRED_ROOT --gt GT_ROOT --matches 128057 132831 \\
         --tolerances 1 5
 """
 from __future__ import annotations

--- a/src/evaluation/gs_hota.py
+++ b/src/evaluation/gs_hota.py
@@ -5,7 +5,7 @@ Thin wrapper around the reference SoccerNet GSR implementation
 metric — we convert SoccerTrack v2's on-disk format into the SoccerNet GSR
 expected layout and call the upstream scorer.
 
-    python -m src.evaluation.gs_hota --pred PRED_ROOT --gt GT_ROOT [--matches 117098 117099]
+    python -m src.evaluation.gs_hota --pred PRED_ROOT --gt GT_ROOT [--matches 128057 132831]
 
 See docs/format-gsr.md for the on-disk annotation layout.
 """

--- a/src/evaluation/mot_hota.py
+++ b/src/evaluation/mot_hota.py
@@ -4,7 +4,7 @@ Runs HOTA / IDF1 / MOTA on MOTChallenge-format predictions. Ground truth is the
 `mot/<match_id>/gt/gt.txt` shipped with SoccerTrack v2; predictions must live under
 `<pred_root>/<match_id>/data.txt` in the same format.
 
-    python -m src.evaluation.mot_hota --pred PRED_ROOT --gt GT_ROOT --matches 117099 \\
+    python -m src.evaluation.mot_hota --pred PRED_ROOT --gt GT_ROOT --matches 128057 132831 \\
         --metrics HOTA IDF1 MOTA
 """
 from __future__ import annotations


### PR DESCRIPTION
## What was wrong

The dataset is documented throughout the repo as ten matches with the contiguous IDs `117091`–`117100`. **That range is fabricated.** Only `117092` and `117093` are real. The ten match IDs actually on disk — verified in both `data/raw/` and `data/production/{gsr,mot,bas}/` — are:

```
117092  117093  118575  118576  118577  118578  128057  128058  132831  132877
```

So eight of the ten documented IDs (`117091`, `117094`–`117100`) point at matches that do not exist. This PR replaces all 67 occurrences of those eight across 18 files.

## Two kinds of occurrence, fixed separately

**1. Factual claims about dataset contents** — these actively mislead users about what they are downloading.

- `docs/matches.json` — all ten entries were keyed by phantom IDs. Rekeyed to the real ten, in ascending order.
- `docs/task-mot.html` — the MOT directory-tree illustration listed a `117094/` directory that does not exist.

**2. Run-blocking split configuration** — the highest-priority fix here.

`baselines/{gsr,bas,mot}/config.yaml` declared `train_matches` / `val_matches` / `test_matches` over matches that cannot be loaded, so **no baseline run could succeed**. Corrected to:

| split | matches |
|---|---|
| test | `128057`, `132831` |
| val | `118578` |
| train | `117092`, `117093`, `118575`, `118576`, `118577`, `128058`, `132877` |

This reproduces the public **SoccerTrack Challenge 2025** split — that challenge trained on `117092`/`117093` and evaluated on `128057`/`132831` — so numbers produced by these baselines stay comparable to the challenge's public submissions. It also places every match carrying bounding-box ground truth in `train`, which is what detector fine-tuning needs.

**3. Copy-pasteable examples** in docs, shell scripts and module docstrings that named nonexistent matches — a user pasting these got a match ID that resolves to nothing. Single-match examples now use `117093` (the most fully processed match on disk — the only one of the ten carrying a `_calibrated_keypoints.json`). Evaluation examples now name the real test matches. Download-subset examples use `117092 117093`.

Affected: `README.md`, `docs/{cli,setup,data_processing}.md`, `docs/{index,index-ja,task-bas,task-gsr,task-mot}.html`, `scripts/{download,create_ground_truth}.sh`, `src/evaluation/{gs_hota,bas_map,mot_hota}.py`.

## Deliberately left alone

- **`docs/matches.json` metadata values stay `null`** (`date`, `weather`, `location`, `kickoff_local`, `duration_min`, `gsr_frames`, `bas_events`). Real per-match metadata exists, but whether to publish team identities is an unresolved decision, so this PR only fixes the keys.
- `team_left` / `team_right` keep their existing anonymised `A1`…`J2` placeholders.

## Verification

- Zero remaining occurrences of any of the eight phantom IDs (`117091`, `117094`, `117095`, `117096`, `117097`, `117098`, `117099`, `117100`).
- `117092` and `117093` verified intact — net occurrences went **up** (40→45 and 137→144), never down. No real ID was rewritten.
- `docs/matches.json` parses; all three baseline configs parse and load the expected split lists.
- The long tail of other six-digit numbers in the repo is `uv.lock` package sizes and notebook frame/event IDs — untouched.

Each replacement was an exact literal string match with an asserted occurrence count, rather than a regex over `1170[0-9]{2}` — a pattern like that would have destroyed the two valid IDs.
