### PR TITLE
Fix the run-blocking match IDs and split in the GSR/BAS/MOT baseline configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The toolkit produces per-match ground truth from raw BePro panoramic recordings.
 
 ```bash
 ./scripts/create_ground_truth.sh 117093          # single match
-./scripts/create_ground_truth.sh 117093 117094   # multiple matches
+./scripts/create_ground_truth.sh 117093 118575   # multiple matches
 ```
 
 Stage-by-stage scripts live under `scripts/` (`trim_video_into_halves.sh`, `convert_raw_to_pitch_plane.sh`, `calibrate_camera.sh`, `convert_pitch_plane_to_image_plane.sh`, `generate_detections.sh`, `convert_coordinates_to_bboxes.sh`, `plot_coordinates_on_video.sh`).

--- a/baselines/bas/config.yaml
+++ b/baselines/bas/config.yaml
@@ -1,8 +1,8 @@
 data:
   root: ./data
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
-  val_matches:   [117098]
-  test_matches:  [117099, 117100]
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]
+  val_matches:   [118578]
+  test_matches:  [128057, 132831]
 
 features:
   name: mvit_b_16x4      # torchvision MViT-V1-B, Kinetics-400 weights

--- a/baselines/gsr/config.yaml
+++ b/baselines/gsr/config.yaml
@@ -6,17 +6,17 @@
 
 data:
   root: ./data                         # SoccerTrack v2 snapshot root (has gsr/, mot/, interim/, ...)
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
-  val_matches:   [117098]
-  test_matches:  [117099, 117100]      # held out for the paper
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]
+  val_matches:   [118578]
+  test_matches:  [128057, 132831]      # held out; matches the SoccerTrack Challenge 2025 test split
 
 # Where the per-match MOT ground-truth annotations live (used to build the YOLO
 # detection dataset for fine-tuning). train.py's mot_path() resolves
-#   <root>/<match>/<filename_template>   with {match}=117099, {half}=1st_half|2nd_half
+#   <root>/<match>/<filename_template>   with {match}=117092, {half}=1st_half|2nd_half
 # The canonical SoccerTrack v2 MOT layout (docs/format-mot.md and
 # src/evaluation/mot_hota.py) is the MOTChallenge gt/gt.txt convention, with each
 # half scored as its own sequence. So the per-half ground truth lives at
-#   data/mot/<match>/<half>/gt/gt.txt   (e.g. data/mot/117099/1st_half/gt/gt.txt)
+#   data/mot/<match>/<half>/gt/gt.txt   (e.g. data/mot/117092/1st_half/gt/gt.txt)
 # i.e. the documented per-sequence `gt/gt.txt`, one sub-dir per half.
 # filename_template placeholders: {match}, {half} (={1st_half,2nd_half}).
 mot:

--- a/baselines/mot/config.yaml
+++ b/baselines/mot/config.yaml
@@ -11,8 +11,8 @@
 
 data:
   root: ./data                          # SoccerTrack v2 snapshot root (has mot/, interim/, ...)
-  train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]  # bare match ids
-  val_matches:   [117098]                                                   # bare match ids
+  train_matches: [117092, 117093, 118575, 118576, 118577, 128058, 132877]  # bare match ids
+  val_matches:   [118578]                                                   # bare match ids
   # test_matches are TrackEval SEQUENCE NAMES (one per half), not bare match ids:
   # baselines/mot/eval.py passes these straight to TrackEval to pair
   #   <pred_root>/<tracker>/data/<seq>.txt  against  <data.root>/mot/<seq>/gt/gt.txt
@@ -21,7 +21,7 @@ data:
   # nested under a MOT17-custom split folder). train.py's parse_test_sequence()
   # recovers (match_id, half) from each name.
   # docs/format-mot.md: score each half as its own sequence with a distinct name.
-  test_matches:  [117099_1st, 117099_2nd, 117100_1st, 117100_2nd]
+  test_matches:  [128057_1st, 128057_2nd, 132831_1st, 132831_2nd]
 
 # Per-match MOT ground-truth annotations used to BUILD the YOLO detection dataset
 # (train/val matches only). build_yolo_dataset (reused from gsr.train) resolves
@@ -30,22 +30,22 @@ data:
 # !! GROUND-TRUTH PATH CONVENTIONS — read before laying out data/mot !!
 # This tree must satisfy TWO physically different GT path shapes (build vs scoring),
 # and the half token is spelled differently in each. A released data/mot must
-# contain both. The train/val matches (117091-117098) and test matches
-# (117099-117100) are DISJOINT, so the two shapes never collide on one file, but
-# every match folder still has to follow whichever shape its role demands.
+# contain both. The train/val matches and the test matches (128057 and 132831)
+# are DISJOINT, so the two shapes never collide on one file, but every match
+# folder still has to follow whichever shape its role demands.
 #
 # 1) BUILD (this section; train/val matches; half = '1st_half' / '2nd_half'):
 #      <mot.root>/<match>/<half>/gt/gt.txt
-#      e.g. data/mot/117091/1st_half/gt/gt.txt
+#      e.g. data/mot/117092/1st_half/gt/gt.txt
 #    Driven by mot.filename_template below and the {half} values in gsr.train.
 #
 # 2) SCORING (test matches; per-half SEQUENCE name, half token = '1st' / '2nd'):
 #    The evaluator src.evaluation.mot_hota sets SKIP_SPLIT_FOL=True, so TrackEval
 #    reads GT at the un-nested, sequence-named path:
 #      <data.root>/mot/<match>_<half>/gt/gt.txt   (+ a seqinfo.ini per sequence)
-#      e.g. data/mot/117099_1st/gt/gt.txt  and  data/mot/117099_1st/seqinfo.ini
+#      e.g. data/mot/128057_1st/gt/gt.txt  and  data/mot/128057_1st/seqinfo.ini
 #    (Historical note: with TrackEval's default SKIP_SPLIT_FOL=False it would
-#    instead nest under data/mot/MOT17-custom/117099_1st/gt/gt.txt — that nesting
+#    instead nest under data/mot/MOT17-custom/128057_1st/gt/gt.txt — that nesting
 #    is the bug this evaluator now suppresses; do NOT lay out a MOT17-custom dir.)
 #
 # Note the half-suffix mismatch: BUILD uses '1st_half'/'2nd_half' (a sub-dir),

--- a/baselines/mot/train.py
+++ b/baselines/mot/train.py
@@ -55,19 +55,19 @@ SoccerTrack v2 keys GSR/BAS per half but MOT sequences per ``<match_id>``. Becau
 the released MOT ground truth is per-half (``data/mot/<match>/<half>/gt/gt.txt``,
 see baselines/gsr/config.yaml), and TrackEval pairs a ``gt/gt.txt`` against a
 ``data.txt`` by *sequence name*, we score **each half as its own sequence** named
-``<match>_<half>`` (e.g. ``117099_1st``) — exactly the convention docs/format-mot.md
+``<match>_<half>`` (e.g. ``128057_1st``) — exactly the convention docs/format-mot.md
 recommends for separately-evaluated halves. Predictions are written in the native
 MOTChallenge ``trackers/<tracker>/data/<seq>.txt`` layout that TrackEval expects::
 
     <pred_root>/<tracker>/data/<match>_<half>.txt
 
-(e.g. ``<pred_root>/bytetrack/data/117099_1st.txt``). For this to be scoreable,
+(e.g. ``<pred_root>/bytetrack/data/128057_1st.txt``). For this to be scoreable,
 the ground truth must sit at ``<gt_root>/<match>_<half>/gt/gt.txt`` with a
 ``seqinfo.ini`` per sequence, and :mod:`src.evaluation.mot_hota` must set
 ``SKIP_SPLIT_FOL=True`` so neither side is nested under a ``MOT17-custom`` split
 folder (it does). The companion ``baselines/mot/eval.py`` reads
 ``cfg.data.test_matches`` as the list of sequence names, so ``config.yaml`` lists
-the per-half sequence names there (e.g. ``117099_1st``) and :func:`sequence_name`
+the per-half sequence names there (e.g. ``128057_1st``) and :func:`sequence_name`
 keeps the train.py naming in lockstep.
 
 Run::
@@ -111,7 +111,7 @@ _MOT_VISIBILITY = 1     # predictions report full visibility (unknown -> 1).
 # --------------------------------------------------------------------------- #
 
 def sequence_name(match_id: str | int, half: int) -> str:
-    """Sequence name for one half, e.g. ``("117099", 1) -> "117099_1st"``.
+    """Sequence name for one half, e.g. ``("128057", 1) -> "128057_1st"``.
 
     This is the key TrackEval uses to pair a prediction ``data.txt`` against a
     ground-truth ``gt/gt.txt`` (docs/format-mot.md). It must match the per-half
@@ -129,7 +129,7 @@ def parse_test_sequence(seq: str | int) -> tuple[str, int]:
 
     The MOT evaluator (baselines/mot/eval.py) consumes ``cfg.data.test_matches``
     as TrackEval **sequence names**, so to keep train.py and eval.py in lockstep
-    we list per-half sequence names there (e.g. ``117099_1st``) and recover the
+    we list per-half sequence names there (e.g. ``128057_1st``) and recover the
     match id + half here for video/ground-truth resolution.
 
     Accepts ``"<match>_1st"`` / ``"<match>_2nd"``. A bare ``"<match>"`` (no half
@@ -141,7 +141,7 @@ def parse_test_sequence(seq: str | int) -> tuple[str, int]:
     if not sep or suffix not in _SUFFIX_HALF:
         raise ValueError(
             f"test sequence {s!r} must end in a half suffix "
-            f"({'/'.join(_HALF_SUFFIX.values())}), e.g. '117099_1st'. "
+            f"({'/'.join(_HALF_SUFFIX.values())}), e.g. '128057_1st'. "
             "List per-half sequence names in cfg.data.test_matches."
         )
     return base, _SUFFIX_HALF[suffix]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ The project includes shell scripts for common operations:
 
 2. **Download the dataset from Hugging Face**
    ```bash
-   ./scripts/download.sh --dest ./data --match 117099 --match 117100
+   ./scripts/download.sh --dest ./data --match 117092 --match 117093
    ```
    Thin wrapper around `huggingface-cli` / `hf` with per-match filtering and revision pinning.
 

--- a/docs/data_processing.md
+++ b/docs/data_processing.md
@@ -47,7 +47,7 @@ Example:
 
 Process multiple matches:
 ```bash
-./scripts/create_ground_truth.sh 117093 117094 117095
+./scripts/create_ground_truth.sh 117093 118575 118576
 ```
 
 ### Individual Steps

--- a/docs/format-mot.md
+++ b/docs/format-mot.md
@@ -147,7 +147,7 @@ Run:
 ```bash
 python -m src.evaluation.mot_hota \
     --pred PRED_ROOT --gt GT_ROOT \
-    --matches 117099 117100 \
+    --matches 128057 132831 \
     --metrics HOTA IDF1 MOTA
 ```
 

--- a/docs/index-ja.html
+++ b/docs/index-ja.html
@@ -523,7 +523,7 @@
 ./scripts/download.sh --dest ./data
 
 # 評価用試合のみ
-./scripts/download.sh --dest ./data --match 117099 --match 117100</code></pre>
+./scripts/download.sh --dest ./data --match 117092 --match 117093</code></pre>
                 </div>
             </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,7 +545,7 @@
 ./scripts/download.sh --dest ./data
 
 # held-out test matches only
-./scripts/download.sh --dest ./data --match 117099 --match 117100</code></pre>
+./scripts/download.sh --dest ./data --match 117092 --match 117093</code></pre>
                 </div>
             </section>
 
@@ -617,9 +617,9 @@ for p in match.gsr_frames(half=1)[0].entities:
                 </p>
 
                 <h3 style="color: #10b981; margin-top: 1.5rem; margin-bottom: 0.5rem;">4. Evaluate</h3>
-                <pre><code>python -m src.evaluation.gs_hota  --pred preds/gsr --gt data/gsr --matches 117099 117100
-python -m src.evaluation.bas_map  --pred preds/bas --gt data/bas --matches 117099 117100
-python -m src.evaluation.mot_hota --pred preds/mot --gt data/mot --matches 117099 117100</code></pre>
+                <pre><code>python -m src.evaluation.gs_hota  --pred preds/gsr --gt data/gsr --matches 128057 132831
+python -m src.evaluation.bas_map  --pred preds/bas --gt data/bas --matches 128057 132831
+python -m src.evaluation.mot_hota --pred preds/mot --gt data/mot --matches 128057 132831</code></pre>
                 <p style="margin-top: 0.75rem;">
                     Starter kits:
                     <a href="https://github.com/AtomScott/SoccerTrack-v2/tree/main/baselines"

--- a/docs/matches.json
+++ b/docs/matches.json
@@ -3,15 +3,15 @@
   "schema_version": 1,
   "updated": "2026-04-22",
   "matches": [
-    { "match_id": "117091", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "A1", "team_right": "A2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117092", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "B1", "team_right": "B2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117093", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "C1", "team_right": "C2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117094", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "D1", "team_right": "D2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117095", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "E1", "team_right": "E2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117096", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "F1", "team_right": "F2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117097", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "G1", "team_right": "G2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117098", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "H1", "team_right": "H2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117099", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "I1", "team_right": "I2", "gsr_frames": null, "bas_events": null },
-    { "match_id": "117100", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "J1", "team_right": "J2", "gsr_frames": null, "bas_events": null }
+    { "match_id": "117092", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "A1", "team_right": "A2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "117093", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "B1", "team_right": "B2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118575", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "C1", "team_right": "C2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118576", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "D1", "team_right": "D2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118577", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "E1", "team_right": "E2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "118578", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "F1", "team_right": "F2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "128057", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "G1", "team_right": "G2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "128058", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "H1", "team_right": "H2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "132831", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "I1", "team_right": "I2", "gsr_frames": null, "bas_events": null },
+    { "match_id": "132877", "date": null, "weather": null, "location": null, "kickoff_local": null, "duration_min": null, "team_left": "J1", "team_right": "J2", "gsr_frames": null, "bas_events": null }
   ]
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,7 +37,7 @@ Use the helper script to fetch from Hugging Face (`atomscott/soccertrack-v2`):
 
 ```bash
 ./scripts/download.sh --dest ./data                                    # full dataset
-./scripts/download.sh --dest ./data --match 117099 --match 117100      # subset
+./scripts/download.sh --dest ./data --match 117092 --match 117093      # subset
 ```
 
 `--revision` pins a dataset tag / commit; see `scripts/download.sh --help` for
@@ -50,7 +50,7 @@ Run a quick load against the freshly downloaded data:
 
 ```python
 from src.data_utils.soccertrack_v2 import load_match
-m = load_match("./data", match_id="117099")
+m = load_match("./data", match_id="117093")
 frames = m.gsr_frames(half=1)
 print(len(frames), "GSR frames in 1st half")
 print(len(m.bas_events()), "BAS events")
@@ -89,7 +89,7 @@ running `download.sh` first:
 
 ```python
 from src.data_utils.load_from_hf import load_match_from_hf
-m = load_match_from_hf("117099")
+m = load_match_from_hf("117093")
 ```
 
 `snapshot_download` caches under `HF_HOME` so repeat calls are free.

--- a/docs/task-bas.html
+++ b/docs/task-bas.html
@@ -387,7 +387,7 @@
                 </ul>
                 <p>Reference CLI:</p>
                 <pre><code>python -m src.evaluation.bas_map \
-    --pred preds/bas --gt data/bas --matches 117099 117100 \
+    --pred preds/bas --gt data/bas --matches 128057 132831 \
     --tolerances 1 5</code></pre>
             </section>
 

--- a/docs/task-gsr.html
+++ b/docs/task-gsr.html
@@ -379,7 +379,7 @@
                     Reference CLI:
                 </p>
                 <pre><code>python -m src.evaluation.gs_hota \
-    --pred preds/gsr --gt data/gsr --matches 117099 117100</code></pre>
+    --pred preds/gsr --gt data/gsr --matches 128057 132831</code></pre>
                 <p>
                     The module is a thin wrapper over the upstream
                     <a href="https://github.com/SoccerNet/sn-gamestate">sn-gamestate</a> scorer.

--- a/docs/task-mot.html
+++ b/docs/task-mot.html
@@ -296,7 +296,7 @@
 │   │   ├── gt/
 │   │   │   └── gt.txt
 │   │   └── seqinfo.ini
-│   ├── 117094/
+│   ├── 118575/
 │   │   └── ...
 │   └── ...
 └── raw/
@@ -386,7 +386,7 @@ imExt=.mp4</code></pre>
                 </p>
                 <p>Reference CLI:</p>
                 <pre><code>python -m src.evaluation.mot_hota \
-    --pred preds/mot --gt data/mot --matches 117099 117100</code></pre>
+    --pred preds/mot --gt data/mot --matches 128057 132831</code></pre>
                 <p>
                     Challenge leaderboard: see <a href="https://sites.google.com/g.sp.m.is.nagoya-u.ac.jp/stc2025" style="color: #ff6b35;">SoccerTrack Challenge 2025</a>.
                 </p>

--- a/scripts/create_ground_truth.sh
+++ b/scripts/create_ground_truth.sh
@@ -4,7 +4,7 @@
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <match_id1> [match_id2 ...]"
     echo "Example: $0 117093"
-    echo "Example with multiple matches: $0 117093 117094 117095"
+    echo "Example with multiple matches: $0 117093 118575 118576"
     exit 1
 fi
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -7,7 +7,7 @@
 #   --dest DIR       Target directory (default: ./data)
 #   --revision REV   Pin to a specific dataset revision / tag / commit (default: main)
 #   --match ID       Repeatable. Restrict download to one or more match IDs
-#                    (e.g. --match 117099 --match 117100). Selects gsr/<id>, bas/<id>,
+#                    (e.g. --match 117092 --match 117093). Selects gsr/<id>, bas/<id>,
 #                    mot/<id>, raw/<id>, videos/<id>*. Mutually exclusive with --include.
 #   --include PAT    Repeatable raw include pattern forwarded to huggingface-cli.
 #

--- a/src/evaluation/bas_map.py
+++ b/src/evaluation/bas_map.py
@@ -4,7 +4,7 @@ Computes per-class temporal mean Average Precision at user-supplied tolerance
 windows (1 s and 5 s by default), matching the SoccerNet BAS protocol. Predictions
 must use the same JSON schema as ground truth (see docs/format-bas.md).
 
-    python -m src.evaluation.bas_map --pred PRED_ROOT --gt GT_ROOT --matches 117099 117100 \\
+    python -m src.evaluation.bas_map --pred PRED_ROOT --gt GT_ROOT --matches 128057 132831 \\
         --tolerances 1 5
 """
 from __future__ import annotations

--- a/src/evaluation/gs_hota.py
+++ b/src/evaluation/gs_hota.py
@@ -16,7 +16,7 @@ This module does **not** reimplement the metric. It:
      (``run_upstream_gs_hota``) so the dependency surface is a single, swappable
      seam.
 
-    python -m src.evaluation.gs_hota --pred PRED_ROOT --gt GT_ROOT --matches 117099 117100
+    python -m src.evaluation.gs_hota --pred PRED_ROOT --gt GT_ROOT --matches 128057 132831
 
 Why the upstream call is isolated behind one function
 -----------------------------------------------------

--- a/src/evaluation/mot_hota.py
+++ b/src/evaluation/mot_hota.py
@@ -9,7 +9,7 @@ Resolved on-disk layout (verified against the installed TrackEval, see below):
 * Predictions:   ``<pred_root>/<tracker>/data/<seq>.txt``
 
 where ``<seq>`` is each ``--matches`` entry (a TrackEval sequence name such as
-``117099_1st``) and ``<tracker>`` is one prediction-run directory under
+``128057_1st``) and ``<tracker>`` is one prediction-run directory under
 ``<pred_root>`` (auto-discovered when ``--tracker`` is not given). This is the
 native MOTChallenge ``trackers/<tracker>/data/<seq>.txt`` convention.
 
@@ -26,7 +26,7 @@ folder for both GT and trackers, so the paths above resolve as documented.
 ``SKIP_SPLIT_FOL=False`` the un-nested layout raises
 ``ini file does not exist: <seq>/seqinfo.ini``; with it True the same data scores.)
 
-    python -m src.evaluation.mot_hota --pred PRED_ROOT --gt GT_ROOT --matches 117099 \\
+    python -m src.evaluation.mot_hota --pred PRED_ROOT --gt GT_ROOT --matches 128057 132831 \\
         --metrics HOTA IDF1 MOTA
 """
 from __future__ import annotations
@@ -49,7 +49,7 @@ def score_many(
         pred_root: directory containing one tracker run sub-dir, predictions at
             ``<pred_root>/<tracker>/data/<seq>.txt``.
         gt_root: directory containing ``<seq>/gt/gt.txt`` + ``<seq>/seqinfo.ini``.
-        match_ids: TrackEval sequence names (e.g. ``["117099_1st", ...]``).
+        match_ids: TrackEval sequence names (e.g. ``["128057_1st", ...]``).
         metrics: subset of ``HOTA`` / ``IDF1`` / ``MOTA`` (default: all three).
         tracker: name of the tracker sub-dir under ``pred_root`` to evaluate. If
             ``None``, TrackEval auto-discovers every sub-dir of ``pred_root``.


### PR DESCRIPTION
Targets `baselines/implement-gsr-bas-mot` so it flows into #16 rather than landing on `main` separately. The `main`-only half of this fix is #17.

## The run-blocking bug

`baselines/{gsr,bas,mot}/config.yaml` declare their splits over match IDs that **do not exist**:

```yaml
train_matches: [117091, 117092, 117093, 117094, 117095, 117096, 117097]
val_matches:   [117098]
test_matches:  [117099, 117100]
```

The documented ID range `117091`–`117100` is fabricated. Only `117092` and `117093` are real. The ten matches actually on disk — verified in both `data/raw/` and `data/production/{gsr,mot,bas}/` — are:

```
117092  117093  118575  118576  118577  118578  128057  128058  132831  132877
```

So eight of the ten IDs the baselines reference resolve to nothing. Every stage that builds a path from a match ID — the MOT→YOLO dataset builder, the video loader, the TrackEval GT lookup — fails. **As written, no baseline run can succeed.** This is the highest-priority fix.

## The corrected split

| split | matches |
|---|---|
| test | `128057`, `132831` |
| val | `118578` |
| train | `117092`, `117093`, `118575`, `118576`, `118577`, `128058`, `132877` |

This reproduces the public **SoccerTrack Challenge 2025** split — that challenge trained on `117092`/`117093` and evaluated on `128057`/`132831` — so numbers these baselines produce stay comparable to the challenge's public submissions. It also puts every match carrying bounding-box ground truth in `train`, which is what the detector fine-tuning needs.

## `baselines/mot/config.yaml` needed more than an ID swap

Three things beyond the split keys:

1. **`test_matches` are TrackEval per-half sequence names**, not bare IDs — `[117099_1st, 117099_2nd, 117100_1st, 117100_2nd]` becomes `[128057_1st, 128057_2nd, 132831_1st, 132831_2nd]`. `parse_test_sequence()` recovers `(match_id, half)` from these, so the half suffixes have to survive the rename.
2. **The "DISJOINT" note described the splits as two contiguous ID ranges** (`117091-117098` vs `117099-117100`). The real IDs are not contiguous, so that framing no longer works; the note is restated naming the test matches directly instead of a range. The claim it makes (build-shape and scoring-shape GT paths never collide on one file) is still true and unchanged.
3. **Path examples now match their role.** Examples illustrating BUILD inputs (train/val matches) use a real *train* match, `117092`; examples illustrating scoring use a real test sequence, `128057_1st`. Same in `baselines/gsr/config.yaml` and the `baselines/mot/train.py` docstrings.

## Also fixed

- **`docs/matches.json`** — all ten entries were keyed by phantom IDs. Rekeyed to the real ten, ascending.
- **Factual claim**: `docs/task-mot.html`'s directory tree listed a `117094/` directory that does not exist.
- **Copy-pasteable examples** in `docs/{cli,setup,data_processing,format-mot}.md`, `docs/{index,index-ja,task-*}.html`, `scripts/{download,create_ground_truth}.sh`, `README.md` and `src/evaluation/{gs_hota,bas_map,mot_hota}.py` docstrings. Single-match examples use `117093` (most fully processed match on disk); evaluation examples name the real test matches.

90 phantom occurrences across 20 files.

## Deliberately left alone

- **`docs/matches.json` metadata stays `null`** (`date`, `weather`, `location`, `kickoff_local`, `duration_min`, `gsr_frames`, `bas_events`). Real per-match metadata exists, but publishing team identities is an unresolved decision. `team_left`/`team_right` keep their anonymised `A1`…`J2` placeholders.
- `docs/format-gsr.md`, `docs/format-bas.md`, `src/data_utils/{soccertrack_v2,load_from_hf}.py`, `notebooks/quickstart.ipynb` and `.github/ISSUE_TEMPLATE/dataset_issue.yml` already used real IDs (`117092`/`117093`) — no change needed.
- `docs/format-mot.md`'s eval example passes bare IDs to `--matches` where the documented contract is sequence names. That inconsistency predates this PR and is out of scope; only the IDs were corrected.

## Verification

- Zero remaining occurrences of any of the eight phantom IDs.
- `117092`/`117093` intact — net occurrences went **up** (51→59, 140→147), never down.
- All three baseline configs parse and load the expected split lists; `docs/matches.json`, `notebooks/quickstart.ipynb` and `dataset_issue.yml` parse; all touched Python files parse.

Every replacement was an exact literal string match with an asserted occurrence count. A regex like `1170[0-9]{2}` would have destroyed the two valid IDs.