### PR TITLE
Make BAS evaluation runnable: four defects, none of which allowed a single file to load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ serve-docs:
 # Pitch space only -- SoccerTrack v2 has no ground-truth detections.
 gs-hota-test:
 	.venv/bin/python tests/test_gs_hota_identity.py
+
+# Prove the BAS plumbing: score ground truth against itself, which must give mAP 1.0.
+bas-map-test:
+	.venv/bin/python tests/test_bas_map_identity.py

--- a/src/data_utils/soccertrack_v2.py
+++ b/src/data_utils/soccertrack_v2.py
@@ -24,6 +24,15 @@ Role = Literal["player", "goalkeeper", "referee", "other"]
 TeamSide = Literal["left", "right"]
 
 FPS: int = 25
+
+# Nominal length of one half in milliseconds. BAS `position` values and the `gameTime`
+# clock are ABSOLUTE from the start of the match, not relative to the half -- verified on
+# 117093, whose half-2 events run 2,700,760..5,506,280 ms with gameTime "2 - 45:00" rather
+# than restarting near zero. docs/format-bas.md and the paper both state the opposite
+# ("milliseconds from kickoff of the half indicated in gameTime") and give a cross-reference
+# formula of floor(position/40), which misaligns every half-2 event by 45 minutes. Whichever
+# of the two is made authoritative, the other must change.
+HALF_MS: int = 45 * 60 * 1000
 BAS_LABELS: tuple[str, ...] = (
     "Pass",
     "Drive",
@@ -82,9 +91,27 @@ class Event:
     visibility: Optional[str] = None
 
     @property
+    def t_ms_in_half(self) -> int:
+        """Milliseconds since kickoff *of this half*.
+
+        `t_ms` is absolute from the start of the match (see HALF_MS), so the per-half video
+        offset needs the whole halves before it subtracted.
+
+        APPROXIMATE. This subtracts a NOMINAL 45-minute half, but real halves run over: with
+        stoppage, half-2 events reach ~48 minutes of in-half time and a few sit slightly
+        before the nominal boundary, giving small negative values. For frame-exact alignment
+        use the per-period frameStart in <match>_tracker_box_metadata.xml instead of this.
+        """
+        return self.t_ms - (self.half - 1) * HALF_MS
+
+    @property
     def image_id(self) -> int:
-        """Frame index in the half video (assuming FPS = 25)."""
-        return int(round(self.t_ms * FPS / 1000))
+        """Frame index within this half's video (assuming FPS = 25).
+
+        Uses t_ms_in_half, not t_ms. Using the absolute time here -- as this property did
+        before -- put every half-2 event 67,500 frames late.
+        """
+        return int(round(self.t_ms_in_half * FPS / 1000))
 
 
 @dataclass
@@ -175,17 +202,60 @@ def _player_from(r: dict) -> Player:
     )
 
 
+# The released BAS files spell labels in UPPER CASE ("HIGH PASS") while BAS_LABELS -- and
+# the paper -- use Title Case ("High Pass"). The label *set* is identical, so this is purely
+# a casing mismatch. Canonicalise on read so the public API keeps the documented spelling.
+_BAS_LABEL_BY_CASEFOLD = {label.casefold(): label for label in BAS_LABELS}
+
+# Likewise the event array is called "actions" in the released files, not "annotations".
+_BAS_EVENT_KEYS = ("actions", "annotations")
+
+
 def _parse_bas(path: Path) -> Iterator[Event]:
+    """Parse one match's BAS events.
+
+    Tolerates two divergences between the released files and what docs/format-bas.md and
+    the paper describe, because as shipped this function could not read a single real file:
+
+      * the event array is keyed "actions", not "annotations" (KeyError on every file);
+      * labels are UPPER CASE, not Title Case (ValueError on every event, since unknown
+        labels raise rather than being skipped).
+
+    Both are accepted; labels are canonicalised to the documented Title Case spelling. An
+    unrecognised label still raises -- silently dropping events would understate recall.
+    """
     if not path.exists():
         raise FileNotFoundError(f"BAS annotation not found: {path}")
     data = json.loads(path.read_text())
-    for a in data["annotations"]:
-        half_str, clock = a["gameTime"].split(" - ")
-        label = a["label"]
-        if label not in BAS_LABELS:
-            raise ValueError(f"Unknown BAS label in {path.name}: {label!r}")
+    for key in _BAS_EVENT_KEYS:
+        if key in data:
+            events = data[key]
+            break
+    else:
+        raise KeyError(
+            f"{path.name} has none of {_BAS_EVENT_KEYS}; top-level keys are {sorted(data)}"
+        )
+    for a in events:
+        gt = str(a["gameTime"])
+        if " - " in gt:
+            half_str, clock = gt.split(" - ", 1)
+            half = int(half_str)
+        else:
+            # Three matches (117092, 132831, 132877) carry a third block of events whose
+            # gameTime omits the half prefix entirely ("90:01"). Their `position` continues
+            # past 5,400,000 ms, i.e. beyond 90 minutes, so they are a third period. Infer
+            # the period from the clock rather than dropping the events silently.
+            clock = gt
+            half = int(int(a["position"]) // HALF_MS) + 1
+        raw = a["label"]
+        label = _BAS_LABEL_BY_CASEFOLD.get(str(raw).casefold())
+        if label is None:
+            raise ValueError(
+                f"Unknown BAS label in {path.name}: {raw!r}. Expected one of {BAS_LABELS} "
+                "(case-insensitive)."
+            )
         yield Event(
-            half=int(half_str),
+            half=half,
             clock=clock,
             t_ms=int(a["position"]),
             label=label,

--- a/tests/test_bas_map_identity.py
+++ b/tests/test_bas_map_identity.py
@@ -1,0 +1,100 @@
+"""BAS plumbing test: scoring ground truth against itself must give mAP == 1.0.
+
+Same principle as tests/test_gs_hota_identity.py. If the parser or the AP computation is
+wrong, a perfect "prediction" will not score 1.0.
+
+This test would have caught all four defects fixed alongside it, each of which made BAS
+evaluation impossible rather than merely inaccurate:
+
+  1. the event array is keyed "actions", not "annotations"  -> KeyError on every file
+  2. labels are UPPER CASE, not Title Case                  -> ValueError on every event
+  3. three matches carry a third period whose gameTime omits the half prefix ("90:01")
+                                                            -> ValueError on unpack
+  4. `position` is absolute from match start, not per-half, so Event.image_id put every
+     half-2 event 67,500 frames late
+
+The BAS files are small (a few hundred KB), so unlike the GSR test this runs over all ten
+matches directly with no slicing.
+
+Run:
+    .venv/bin/python -m pytest tests/test_bas_map_identity.py -q -s
+    .venv/bin/python tests/test_bas_map_identity.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Resolve THIS checkout's src/, not whatever the venv's editable install points at. The
+# project is installed in editable mode against a different working tree, so without this a
+# test run here silently exercises that other tree's code.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DATA = Path(os.environ.get("DATA", "/data/share/SoccerTrack-v2/data"))
+BAS = DATA / "production" / "bas"
+MATCHES = ["117092", "117093", "118575", "118576", "118577", "118578",
+           "128057", "128058", "132831", "132877"]
+
+
+def _available() -> list[str]:
+    return [m for m in MATCHES if (BAS / m / f"{m}_12_class_events.json").exists()]
+
+
+def test_every_match_parses():
+    """All ten must parse. As shipped, not one of them could be read."""
+    from src.data_utils.soccertrack_v2 import BAS_LABELS, _parse_bas
+
+    matches = _available()
+    assert matches, f"no BAS files under {BAS}"
+    total = 0
+    for m in matches:
+        events = list(_parse_bas(BAS / m / f"{m}_12_class_events.json"))
+        assert events, f"{m}: parsed zero events"
+        total += len(events)
+        for e in events:
+            assert e.label in BAS_LABELS, f"{m}: uncanonicalised label {e.label!r}"
+            assert e.half >= 1
+    print(f"parsed {total} events across {len(matches)} matches")
+    assert total > 20000, f"expected >20k events across the dataset, got {total}"
+
+
+def test_gt_against_itself_scores_one():
+    from src.evaluation.bas_map import score_many
+
+    matches = _available()
+    res = score_many(BAS, BAS, matches)
+    for m in matches:
+        for tol in (1, 5):
+            got = res[m][f"mAP@{tol}s"]
+            assert got > 0.999, f"{m} mAP@{tol}s = {got}, expected ~1.0 scoring GT against itself"
+    print(f"mAP@1s = {res['overall']['mAP@1s']:.4f}   "
+          f"mAP@5s = {res['overall']['mAP@5s']:.4f}   over {len(matches)} matches")
+
+
+def test_position_is_absolute_not_per_half():
+    """Guard the finding that `position` is absolute from match start.
+
+    docs/format-bas.md and the paper both say it is relative to the half's kickoff. It is
+    not: half-2 events do not restart near zero. If a future data release changes this, the
+    per-half offset in Event.t_ms_in_half becomes wrong and this test should fail loudly.
+    """
+    from src.data_utils.soccertrack_v2 import HALF_MS, _parse_bas
+
+    events = list(_parse_bas(BAS / "117093" / "117093_12_class_events.json"))
+    h2 = [e for e in events if e.half == 2]
+    assert h2, "no half-2 events"
+    assert min(e.t_ms for e in h2) > HALF_MS * 0.9, (
+        "half-2 `position` values appear to restart near zero, i.e. they are per-half after "
+        "all. Event.t_ms_in_half and Event.image_id must be revisited."
+    )
+    # ...and the derived per-half offset must land near the start of the half.
+    assert min(e.t_ms_in_half for e in h2) < 60_000
+
+
+if __name__ == "__main__":
+    test_every_match_parses()
+    test_gt_against_itself_scores_one()
+    test_position_is_absolute_not_per_half()
+    print("PASS")


### PR DESCRIPTION
Companion to #21. BAS evaluation was as non-functional as GS-HOTA, for a different set of reasons: **not one of the ten released BAS files could be read by the loader that ships to read them.**

## 1. Wrong top-level key

`_parse_bas` reads `data["annotations"]`; the files key the event array **`actions`**. `KeyError` on the first line of every file. Now accepts either.

## 2. Wrong label case

`BAS_LABELS` declares Title Case (`"High Pass"`); the data is UPPER CASE (`"HIGH PASS"`). Unknown labels **raise** rather than being skipped, so this fails on the first event of every file once (1) is past.

The label *sets* are identical — purely casing. Labels are now matched case-insensitively and canonicalised to the documented Title Case spelling. A genuinely unrecognised label still raises; silently dropping events would understate recall.

## 3. A third period in a different format

`117092`, `132831` and `132877` each carry a further block of events whose `gameTime` **omits the half prefix** (`"90:01"` rather than `"1 - 0:01"`) and whose `position` continues past 5,400,000 ms:

| match | half 1 | half 2 | extra block |
|---|---|---|---|
| 117092 | 1077 | 1058 | **1007** |
| 132831 | 1279 | 1192 | **691** |
| 132877 | 1204 | 1096 | **431** |

2,129 events that crashed the `gameTime` split with *"not enough values to unpack"*. `117092`'s metadata does declare `EXTRA_FIRST_HALF` and `EXTRA_SECOND_HALF`, so these look like genuine extra time. The period is now inferred from `position` rather than the events being dropped.

## 4. `position` is absolute, not per-half — and the docs say otherwise

Verified on `117093`:

```
half 1:  position       680 .. 2,694,000   gameTime "1 - 0:01"  .. "1 - 44:55"
half 2:  position 2,700,760 .. 5,506,280   gameTime "2 - 45:00" .. "2 - 91:46"
```

Half 2 does not restart near zero. Both the clock and `position` are **absolute from the start of the match**.

`docs/format-bas.md` and `sections/02_dataset.tex` both state *"a `position` field giving milliseconds from kickoff of the half indicated in `gameTime`"*, and the paper gives the cross-reference formula `⌊position/40⌋`. Following either **misaligns every half-2 event by 45 minutes.**

`Event.image_id` used `t_ms` directly, so it placed every half-2 event **67,500 frames late**. It now derives from a new `Event.t_ms_in_half`, documented as **approximate**: it subtracts a *nominal* 45-minute half, while real halves run over — half-2 in-half times reach ~48 minutes here, and a few events sit slightly before the nominal boundary, giving small negative values. Frame-exact work should use the per-period `frameStart` in `<match>_tracker_box_metadata.xml`.

**I have not changed the docs or the paper.** Which of the two is authoritative is your call — the data could be relabelled to per-half, or the documentation corrected. `tests/test_bas_map_identity.py` pins the *observed* behaviour so that a future data release switching to per-half timing fails loudly rather than silently.

## Verification

`make bas-map-test`:

```
23,663 events parse across all ten matches      (previously: zero)
mAP@1s = 1.0000   mAP@5s = 1.0000              scoring ground truth against itself
all 12 classes at 1.0 individually
```

As with GS-HOTA, a perfect-prediction score validates parsing, matching and the AP computation. It does **not** exercise the partial-match path — that needs real predictions.

## Note on the test

The test pins `sys.path` to its own checkout. Without that it silently exercises whatever working tree the venv's editable install points at — which bit me while writing it, and would bite anyone running tests from a second clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)